### PR TITLE
make prefix and delimiter configurable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,11 +41,13 @@ function Cacheman(name, options) {
 
   this.options = options || {};
   this.options.count = 1000;
+  this.options.prefix = this.options.prefix || 'cache';
+  this.options.delimiter = this.options.delimiter || ':';
   this._name = name;
   this._fns = [];
   this._ttl = this.options.ttl || 60;
   this.engine(this.options.engine || 'memory');
-  this._prefix = 'cache:' + this._name + ':';
+  this._prefix = this.options.prefix + this.options.delimiter + this._name + this.options.delimiter;
 }
 
 /**


### PR DESCRIPTION
I needed to change the prefix from 'cache:', so I make it configurable. While I was at it, I make the delimiter be configurable as well.
