### PR TITLE
Duplicate of prefix key with sub engine.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ export default class Cacheman {
     this._fns = [];
     this._ttl = this.options.ttl || 60;
     this.engine(this.options.engine || 'memory');
-    this._prefix = this.options.prefix + this.options.delimiter + this._name + this.options.delimiter;
+    this._prefix = this.options.delimiter + this._name + this.options.delimiter;
   }
 
   /**
@@ -61,7 +61,7 @@ export default class Cacheman {
    */
 
   engine(engine, options) {
-    
+
     if (!arguments.length) return this._engine;
 
     let type = typeof engine;
@@ -186,7 +186,7 @@ export default class Cacheman {
         if (err || _err) return fn(err || _err);
 
         let force = false;
-        
+
         if ('undefined' !== typeof _data) {
           force = true;
           data = _data;


### PR DESCRIPTION
Javascript

```javascript
new Cacheman('mcs', {
  prefix: 'api',
  ttl: 180,
  engine: 'redis'
});
```

The prefix key is `apiapi:mcs:xxxxx` so we don't need set prefix key in `cacheman` module.
