### PR TITLE
Change cacheman constructor to more intuitively manage key prefixes.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,13 +42,14 @@ export default class Cacheman {
 
     this.options = options;
     this.options.count = 1000;
-    this.options.prefix = this.options.prefix || 'cache';
     this.options.delimiter = this.options.delimiter || ':';
-    this._name = name || '';
+    this.options.prefix = this.options.prefix || 'cacheman';
+    if (!this.options.prefix.endsWith(this.options.delimiter)) this.options.prefix += this.options.delimiter;
+    this._prefix = name || 'cache';
+    if (!this._prefix.endsWith(this.options.delimiter)) this._prefix += this.options.delimiter;
     this._fns = [];
     this._ttl = this.options.ttl || 60;
     this.engine(this.options.engine || 'memory');
-    this._prefix = this.options.prefix + this.options.delimiter + this._name + this.options.delimiter;
   }
 
   /**


### PR DESCRIPTION
new Cacheman() will yield cacheman:cache:XXXX keys
new Cacheman('name') will yield cacheman:name:XXXX keys
new Cacheman('name', { prefix: 'prefix' }) will yield prefix:name:XXX keys