### PR TITLE
only append prefix if it is not redis engine

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,12 +55,12 @@ export default class Cacheman {
       options = name;
       name = null;
     }
-    
-    let { 
-      prefix = 'cacheman', 
-      engine = 'memory', 
-      delimiter = ':', 
-      ttl = 60 
+
+    let {
+      prefix = 'cacheman',
+      engine = 'memory',
+      delimiter = ':',
+      ttl = 60
     } = options;
 
     prefix = [prefix, name || 'cache', ''].join(delimiter);
@@ -81,7 +81,7 @@ export default class Cacheman {
    */
 
   engine(engine, options) {
-    
+
     if (!arguments.length) return this._engine;
 
     const type = typeof engine;
@@ -135,7 +135,7 @@ export default class Cacheman {
    */
 
   key(key) {
-    return this._prefix + key;
+    return (this.options.engine === 'redis')? key : this._prefix + key;
   }
 
   /**
@@ -205,7 +205,7 @@ export default class Cacheman {
         if (err || _err) return fn(err || _err);
 
         let force = false;
-        
+
         if ('undefined' !== typeof _data) {
           force = true;
           data = _data;


### PR DESCRIPTION
this is for solving the duplicate prefix in the actual redis DB report in this issue:

https://github.com/cayasso/cacheman/issues/26
