### PR TITLE
Pass the correct arguments to Error.captureStackTrace

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,10 +23,9 @@ const engines = ['memory', 'redis', 'mongo', 'file'];
 class CachemanError extends Error {
   constructor(message) {
     super(message);
-    const { name } = this.constructor;
-    this.name = name;
+    this.name = this.constructor.name;
     this.message = message;
-    Error.captureStackTrace(this, name);
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 


### PR DESCRIPTION
The optional argument of [`Error.captureStackTrace`](https://nodejs.org/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt) accepts a function. Using the constructor name has no effect.