### PR TITLE
[pkg] bump cacheman-memory dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 sudo: false
 language: node_js
 node_js:
+  - "10"
+  - "8"
   - "6"
-  - "5"
-  - "4"
-  - "3"
-  - "2"
-  - "1"
-  - "0.12"
-  - "0.10"
 before_install:
   - "npm install npm -g"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pre-commit": "^1.1.2"
   },
   "dependencies": {
-    "cacheman-memory": "^1.0.2",
+    "cacheman-memory": "^1.1.0",
     "ms": "^0.7.1"
   }
 }


### PR DESCRIPTION
The 1.0.2 release of cacheman-memory on npm contains an accidental
inclusion of a `node_modules-` folder (with the '-') from 'npm
shrinkwrap'. As a result, v1.0.2 is ~2MB larger than v1.1.0, so bumping
this dependency saves a bit of download bandwidth and disk space.